### PR TITLE
change "yaml.load" to better "yaml.safe_load"

### DIFF
--- a/dmarchiver.py
+++ b/dmarchiver.py
@@ -34,7 +34,7 @@ except FileNotFoundError:
 
 try:
 	with open(config, 'r') as ymlfile:
-		cfg = yaml.load(ymlfile)
+		cfg = yaml.safe_load(ymlfile)
 
 		imap_host       = cfg['imap']['imap_host']
 		imap_port       = cfg['imap']['imap_port']


### PR DESCRIPTION
https://bugs.gentoo.org/659348

It is reported that in PyYAML before 4.1, usage of yaml.load() function on untrusted input could lead to arbitrary code execution. It is therefore recommended to use yaml.safe_load() instead. With 4.1, yaml.load() has been changed to call safe_load().

* Report:          http://seclists.org/oss-sec/2018/q2/240
* Upstream change: https://github.com/yaml/pyyaml/pull/74
* CVE:             pending

--

Gentoo Security Scout
Vladimir Krstulja